### PR TITLE
Fix unused cleanup interval check

### DIFF
--- a/chatgpt-folder-extension/content.js
+++ b/chatgpt-folder-extension/content.js
@@ -2324,7 +2324,6 @@
 
             // 清理定时器
             try {
-                if (typeof liveSyncCleanerId !== 'undefined') clearInterval(liveSyncCleanerId);
                 if (window.__memoryCheckerId) {
                     clearInterval(window.__memoryCheckerId);
                     window.__memoryCheckerId = null;


### PR DESCRIPTION
## Summary
- remove the stale `liveSyncCleanerId` cleanup logic

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7cb1e8dc832bbd2a34596ac6f404